### PR TITLE
Store vat rates in local file and add failover client

### DIFF
--- a/data/jsonvat_rates.json
+++ b/data/jsonvat_rates.json
@@ -1,0 +1,506 @@
+{
+    "details": "http://github.com/adamcooke/vat-rates",
+    "version": null,
+    "rates": [
+        {
+            "name": "Spain",
+            "code": "ES",
+            "country_code": "ES",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "super_reduced": 4.0,
+                        "reduced": 10.0,
+                        "standard": 21.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Bulgaria",
+            "code": "BG",
+            "country_code": "BG",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 9.0,
+                        "standard": 20.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Hungary",
+            "code": "HU",
+            "country_code": "HU",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 18.0,
+                        "standard": 27.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Latvia",
+            "code": "LV",
+            "country_code": "LV",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 12.0,
+                        "standard": 21.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Poland",
+            "code": "PL",
+            "country_code": "PL",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 8.0,
+                        "standard": 23.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "United Kingdom",
+            "code": "UK",
+            "country_code": "GB",
+            "periods": [
+                {
+                    "effective_from": "2011-01-04",
+                    "rates": {
+                        "standard": 20.0,
+                        "reduced": 5.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Czech Republic",
+            "code": "CZ",
+            "country_code": "CZ",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 15.0,
+                        "standard": 21.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Malta",
+            "code": "MT",
+            "country_code": "MT",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 7.0,
+                        "standard": 18.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Italy",
+            "code": "IT",
+            "country_code": "IT",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "super_reduced": 4.0,
+                        "reduced": 10.0,
+                        "standard": 22.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Slovenia",
+            "code": "SI",
+            "country_code": "SI",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 9.5,
+                        "standard": 22.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Ireland",
+            "code": "IE",
+            "country_code": "IE",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "super_reduced": 4.8,
+                        "reduced1": 9.0,
+                        "reduced2": 13.5,
+                        "standard": 23.0,
+                        "parking": 13.5
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Sweden",
+            "code": "SE",
+            "country_code": "SE",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 6.0,
+                        "reduced2": 12.0,
+                        "standard": 25.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Denmark",
+            "code": "DK",
+            "country_code": "DK",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "standard": 25.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Finland",
+            "code": "FI",
+            "country_code": "FI",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 10.0,
+                        "reduced2": 14.0,
+                        "standard": 24.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Cyprus",
+            "code": "CY",
+            "country_code": "CY",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 9.0,
+                        "standard": 19.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Luxembourg",
+            "code": "LU",
+            "country_code": "LU",
+            "periods": [
+                {
+                    "effective_from": "2016-01-01",
+                    "rates": {
+                        "super_reduced": 3.0,
+                        "reduced1": 8.0,
+                        "standard": 17.0,
+                        "parking": 13.0
+                    }
+                },
+                {
+                    "effective_from": "2015-01-01",
+                    "rates": {
+                        "super_reduced": 3.0,
+                        "reduced1": 8.0,
+                        "reduced2": 14.0,
+                        "standard": 17.0,
+                        "parking": 12.0
+                    }
+                },
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "super_reduced": 3.0,
+                        "reduced1": 6.0,
+                        "reduced2": 12.0,
+                        "standard": 15.0,
+                        "parking": 12.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Romania",
+            "code": "RO",
+            "country_code": "RO",
+            "periods": [
+                {
+                    "effective_from": "2017-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 9.0,
+                        "standard": 19.0
+                    }
+                },
+                {
+                    "effective_from": "2016-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 9.0,
+                        "standard": 20.0
+                    }
+                },
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 9.0,
+                        "standard": 24.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Estonia",
+            "code": "EE",
+            "country_code": "EE",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 9.0,
+                        "standard": 20.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Greece",
+            "code": "EL",
+            "country_code": "GR",
+            "periods": [
+                {
+                    "effective_from": "2016-06-01",
+                    "rates": {
+                        "reduced1": 6.0,
+                        "reduced2": 13.5,
+                        "standard": 24.0
+                    }
+                },
+                {
+                    "effective_from": "2016-01-01",
+                    "rates": {
+                        "reduced1": 6.0,
+                        "reduced2": 13.5,
+                        "standard": 23.0
+                    }
+                },
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 6.5,
+                        "reduced2": 13.0,
+                        "standard": 23.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Lithuania",
+            "code": "LT",
+            "country_code": "LT",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 9.0,
+                        "standard": 21.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "France",
+            "code": "FR",
+            "country_code": "FR",
+            "periods": [
+                {
+                    "effective_from": "2014-01-01",
+                    "rates": {
+                        "super_reduced": 2.1,
+                        "reduced1": 5.5,
+                        "reduced2": 10.0,
+                        "standard": 20.0
+                    }
+                },
+                {
+                    "effective_from": "2012-01-01",
+                    "rates": {
+                        "super_reduced": 2.1,
+                        "reduced1": 5.5,
+                        "reduced2": 7.0,
+                        "standard": 19.6
+                    }
+                },
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "super_reduced": 2.1,
+                        "reduced1": 5.5,
+                        "standard": 19.6
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Croatia",
+            "code": "HR",
+            "country_code": "HR",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 5.0,
+                        "reduced2": 13.0,
+                        "standard": 25.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Belgium",
+            "code": "BE",
+            "country_code": "BE",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 6.0,
+                        "reduced2": 12.0,
+                        "standard": 21.0,
+                        "parking": 12.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Netherlands",
+            "code": "NL",
+            "country_code": "NL",
+            "periods": [
+                {
+                    "effective_from": "2012-10-01",
+                    "rates": {
+                        "reduced": 6.0,
+                        "standard": 21.0
+                    }
+                },
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 6.0,
+                        "standard": 19.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Slovakia",
+            "code": "SK",
+            "country_code": "SK",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 10.0,
+                        "standard": 20.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Germany",
+            "code": "DE",
+            "country_code": "DE",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 7.0,
+                        "standard": 19.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Portugal",
+            "code": "PT",
+            "country_code": "PT",
+            "periods": [
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced1": 6.0,
+                        "reduced2": 13.0,
+                        "standard": 23.0,
+                        "parking": 13.0
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Austria",
+            "code": "AT",
+            "country_code": "AT",
+            "periods": [
+                {
+                    "effective_from": "2016-01-01",
+                    "rates": {
+                        "reduced1": 10.0,
+                        "reduced2": 13.0,
+                        "standard": 20.0,
+                        "parking": 13.0
+                    }
+                },
+                {
+                    "effective_from": "0000-01-01",
+                    "rates": {
+                        "reduced": 10.0,
+                        "standard": 20.0,
+                        "parking": 12.0
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/Rates/Clients/Failover.php
+++ b/src/Rates/Clients/Failover.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DvK\Vat\Rates\Clients;
+
+use DvK\Vat\Rates\Exceptions\ClientException;
+use DvK\Vat\Rates\Interfaces\Client;
+
+/**
+ * Try to fetch the vat rates using the primary client, but fall back to the failover if the primary fails.
+ */
+final class Failover implements Client
+{
+    /**
+     * @var Client
+     */
+    private $primary;
+
+    /**
+     * @var Client
+     */
+    private $failover;
+
+    public function __construct(Client $primary, Client $failover)
+    {
+        $this->primary = $primary;
+        $this->failover = $failover;
+    }
+
+    public function fetch()
+    {
+        try {
+            return $this->primary->fetch();
+        } catch (ClientException $e) {
+            return $this->failover->fetch();
+        }
+    }
+}

--- a/src/Rates/Clients/LocalJsonVat.php
+++ b/src/Rates/Clients/LocalJsonVat.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DvK\Vat\Rates\Clients;
+
+use DvK\Vat\Rates\Exceptions\ClientException;
+use DvK\Vat\Rates\Interfaces\Client;
+
+/**
+ * Returns the data from jsonvat.com from local file that is included in this repository.
+ *
+ * This makes this library independent of jsonvat.com and possible failures.
+ */
+final class LocalJsonVat implements Client
+{
+    public function fetch()
+    {
+        $json = file_get_contents(__DIR__ . '/../../../data/jsonvat_rates.json');
+        $data = json_decode($json, true);
+        $output = array_combine(array_column($data['rates'], 'country_code'), $data['rates']);
+
+        return $output;
+    }
+}

--- a/tests/RatesTest.php
+++ b/tests/RatesTest.php
@@ -3,6 +3,7 @@
 namespace DvK\Tests\Vat;
 
 use DvK\Vat\Rates\Caches\NullCache;
+use DvK\Vat\Rates\Clients\LocalJsonVat;
 use DvK\Vat\Rates\Exceptions\Exception;
 use DvK\Vat\Rates\Rates;
 use DvK\Vat\Rates\Clients\JsonVat;
@@ -227,5 +228,31 @@ class RatesTest extends PHPUnit_Framework_TestCase
         $rates = new Rates( $clientMock, $cacheMock );
     }
 
+    public function test_ratesFromJsonVatCom() {
+        $rates = new Rates(new JsonVat());
 
+        self::assertNotEmpty($rates->all());
+
+        // Return correct VAT rates
+        self::assertEquals($rates->country('NL'), 21);
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2010-01-01')), 19);
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2022-01-01')), 21);
+
+        self::assertEquals($rates->country('NL', 'reduced'), 6);
+        self::assertEquals($rates->country('NL', 'reduced', new \DateTimeImmutable('2010-01-01')), 6);
+    }
+
+    public function test_ratesFromLocalFile() {
+        $rates = new Rates(new LocalJsonVat());
+
+        self::assertNotEmpty($rates->all());
+
+        // Return correct VAT rates
+        self::assertEquals($rates->country('NL'), 21);
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2010-01-01')), 19);
+        self::assertEquals($rates->country('NL', 'standard', new \DateTimeImmutable('2022-01-01')), 21);
+
+        self::assertEquals($rates->country('NL', 'reduced'), 6);
+        self::assertEquals($rates->country('NL', 'reduced', new \DateTimeImmutable('2010-01-01')), 6);
+    }
 }


### PR DESCRIPTION
As jsonvat.com had another certificate issue today I decided to add a client that loads the vat rates from a local file (data from jsonvat.com).

As the file needs to be updated from time to time, I implemented a failover client that tries to fetch data from one client (jsonvat.com) and falls back to another one (the local client) if the first fails. So one can get the current rates, but does not need to fear outages when jsonvat.com is down (even though in that case it's possible to work with outdated data)

fixes #5 and #2 

Tests are failing because I added a test case for jsonvat.com which is currently "down" (SSL certificate error) :wink: 