### PR TITLE
Removed URL encoding for IP2Country for IPv6 support

### DIFF
--- a/src/Geolocation/IP2Country.php
+++ b/src/Geolocation/IP2Country.php
@@ -21,7 +21,7 @@ class IP2Country
             return '';
         }
 
-        $url = sprintf('https://api.ip2country.info/ip?%s', urlencode($ipAddress));
+        $url = sprintf('https://api.ip2country.info/ip?%s', $ipAddress);
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);


### PR DESCRIPTION
As discussed in #26, `urlencode` was causing the colons of IPv6 addresses to be encoded, which is not what the IP2Country.info API expects.