### PR TITLE
Remove unused and wrong namespace Exception import

### DIFF
--- a/src/Clients/Client.php
+++ b/src/Clients/Client.php
@@ -2,8 +2,6 @@
 
 namespace Ibericode\Vat\Clients;
 
-use Ibericode\Vat\Exceptions\Exception;
-
 interface Client
 {
 


### PR DESCRIPTION
The `Ibericode\Vat\Exceptions\Exception` is an unused class in this interface. In addition, it is also referencing the class in the wrong namespace, as its FQCN is `Ibericode\Vat\Exception`. Best to get rid of it.