### PR TITLE
Improve PHPUnit and some testing stuffs

### DIFF
--- a/tests/Clients/ClientsTest.php
+++ b/tests/Clients/ClientsTest.php
@@ -3,7 +3,6 @@
 namespace Ibericode\Vat\Tests\Clients;
 
 use Ibericode\Vat\Clients\IbericodeVatRatesClient;
-use Ibericode\Vat\Clients\JsonVatClient;
 use Ibericode\Vat\Clients\Client;
 use Ibericode\Vat\Period;
 use PHPUnit\Framework\TestCase;

--- a/tests/CountriesTest.php
+++ b/tests/CountriesTest.php
@@ -12,20 +12,15 @@ class CountriesTest extends TestCase
     {
         $countries = new Countries();
 
-        $i = 0;
-        foreach ($countries as $code => $country) {
-            $i++;
-        }
-
-        $this->assertEquals(245, $i);
+        $this->assertCount(245, $countries);
     }
 
     public function testArrayAccess()
     {
         $countries = new Countries();
 
-        $this->assertEquals($countries['AF'], 'Afghanistan');
-        $this->assertEquals($countries['NL'], 'Netherlands');
+        $this->assertEquals('Afghanistan', $countries['AF']);
+        $this->assertEquals('Netherlands', $countries['NL']);
 
         $this->expectException(Exception::class);
         $countries['FOO'];

--- a/tests/RatesTest.php
+++ b/tests/RatesTest.php
@@ -4,7 +4,6 @@ namespace Ibericode\Vat\Tests;
 
 use Ibericode\Vat\Clients\ClientException;
 use Ibericode\Vat\Clients\IbericodeVatRatesClient;
-use Ibericode\Vat\Clients\JsonVatClient;
 use Ibericode\Vat\Exception;
 use Ibericode\Vat\Period;
 use Ibericode\Vat\Rates;
@@ -13,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class RatesTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         if (file_exists('vendor/rates')) {
             unlink('vendor/rates');

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -56,7 +56,7 @@ class ValidatorTest extends TestCase
 
         $validator = new Validator();
         foreach ($valid as $format) {
-            self::assertTrue($validator->validateVatNumberFormat($format), "{$format} did not pass validation.");
+            $this->assertTrue($validator->validateVatNumberFormat($format), "{$format} did not pass validation.");
         }
 
         $invalid = [
@@ -109,7 +109,7 @@ class ValidatorTest extends TestCase
 
         foreach ($invalid as $format) {
             $isValid = $validator->validateVatNumberFormat($format);
-            self::assertFalse($isValid, "{$format} passed validation, but shouldn't.");
+            $this->assertFalse($isValid, "{$format} passed validation, but shouldn't.");
         }
     }
 


### PR DESCRIPTION
# Changed log

- Removing the `use Ibericode\Vat\Clients\JsonVatClient;` namespace because it's declared but not used.
- Switching the arguments order for `assertEquals` assertion because the arguments order is `assertEquals($expected, $actual)`.
- The PHPUnit assertion call approaches are `$this` and `self`. Most of them use `$this` and it should be consistency for them to use the `$this` approach.
- It should be good to use the `assertCount` to assert the `$countries` counts are `245`.
- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should use the `protected function setUp(): void` method.