### PR TITLE
Adding explicit SOAP dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   "require": {
     "php": ">=7.3",
     "ext-curl": "*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-soap": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
This package throws exceptions if the PHP extension for SOAP is not installed.