### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.* export-ignore
+tests export-ignore
+phpcs.xml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hi @dannyvankooten,

When installing this library, composer is also downloading the test folder and related files but they are not needed.
The gitattributes file does prevent this.