### PR TITLE
Add missing EU countries

### DIFF
--- a/src/Countries.php
+++ b/src/Countries.php
@@ -285,7 +285,41 @@ class Countries implements \Iterator, \ArrayAccess
      */
     public function getCountryCodesInEU(): array
     {
-        return ['AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GR', 'HU', 'HR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK'];
+        return [
+            'AT', // Austria
+            'AX', // Aland islands => Finland
+            'BE', // Belgium
+            'BG', // Bulgaria
+            'CY', // Cyprus
+            'CZ', // Czechia
+            'DE', // Germany
+            'DK', // Denmark
+            'EE', // Estonia
+            'ES', // Spain
+            'FI', // Finland
+            'FR', // France
+            'GF', // French guiana => France
+            'GP', // Guadeloupe => France
+            'GR', // Greece
+            'HU', // Hungary
+            'HR', // Croatia
+            'IE', // Ireland
+            'IT', // Italy
+            'LT', // Lithuania
+            'LU', // Luxembourg
+            'LV', // Latvia
+            'MT', // Malta
+            'MQ', // Martinique => France
+            'NL', // Netherlands
+            'PL', // Poland
+            'PT', // Portugal
+            'RE', // Reunion => France
+            'RO', // Romania
+            'SE', // Sweden
+            'SI', // Slovenia
+            'SK', // Slovakia
+            'YT', // Mayotte => France
+        ];
     }
 
     /**


### PR DESCRIPTION
Hi @dannyvankooten,

The EU country list is missing `Overseas Departments and Territories`.

These territories has country code, you can find them in `Countries::$data`, on wikipedia or
https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/regions/en.php
but currently they are not in the `getCountryCodeInEu` method.