### PR TITLE
Allow to chose behavior if country is not supported

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -98,11 +98,10 @@ class Validator
      * Validate a VAT number format. This does not check whether the VAT number was really issued.
      *
      * @param string $vatNumber
-     * @param bool $skipIfUnsupported
      *
      * @return boolean
      */
-    public function validateVatNumberFormat(string $vatNumber, bool $skipIfUnsupported = false): bool
+    public function validateVatNumberFormat(string $vatNumber): bool
     {
         if ($vatNumber === '') {
             return false;
@@ -113,7 +112,7 @@ class Validator
         $number = substr($vatNumber, 2);
 
         if (! isset($this->patterns[$country])) {
-            return $skipIfUnsupported;
+            throw new \InvalidArgumentException('The vat country prefix is not supported.');
         }
 
         return preg_match('/^' . $this->patterns[$country] . '$/', $number) > 0;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -87,14 +87,22 @@ class Validator
         return (bool) filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE);
     }
 
+    public function hasSupportedCountryPrefix(string $vatNumber): bool
+    {
+        $country = substr($vatNumber, 0, 2);
+
+        return isset($this->patterns[$country]);
+    }
+
     /**
      * Validate a VAT number format. This does not check whether the VAT number was really issued.
      *
      * @param string $vatNumber
+     * @param bool $skipIfUnsupported
      *
      * @return boolean
      */
-    public function validateVatNumberFormat(string $vatNumber): bool
+    public function validateVatNumberFormat(string $vatNumber, bool $skipIfUnsupported = false): bool
     {
         if ($vatNumber === '') {
             return false;
@@ -105,7 +113,7 @@ class Validator
         $number = substr($vatNumber, 2);
 
         if (! isset($this->patterns[$country])) {
-            return false;
+            return $skipIfUnsupported;
         }
 
         return preg_match('/^' . $this->patterns[$country] . '$/', $number) > 0;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -96,14 +96,6 @@ class ValidatorTest extends TestCase
             'SI1234567',
             'SK123456789',
 
-            // valid number but with prefix
-            'invalid_prefix_GB999999973',
-            'invalid_prefix_IE1234567X',
-            'invalid_prefix_ESB1234567C',
-            'invalid_prefix_BE0123456789',
-            'invalid_prefix_MT12345678',
-            'invalid_prefix_LT123456789',
-
             // valid number but with suffix
             'IE1234567X_invalid_suffix',
             'ESB1234567C_invalid_suffix',


### PR DESCRIPTION
Closes https://github.com/ibericode/vat/issues/40

cc @gemal @dannyvankooten 

The option doesn't make sens for validateVatNumber, since the `validateVatNumberExistence` only work for EU country since the check is done on https://ec.europa.eu/taxation_customs/vies/#/vat-validation