### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/Rates.php
+++ b/src/Rates.php
@@ -38,7 +38,7 @@ class Rates
      * @param int $refreshInterval How often to check for new VAT rates. Defaults to every 12 hours.
      * @param Client|null $client The VAT client to use.
      */
-    public function __construct(string $storagePath, int $refreshInterval = 12 * 3600, Client $client = null)
+    public function __construct(string $storagePath, int $refreshInterval = 12 * 3600, ?Client $client = null)
     {
         $this->refreshInterval = $refreshInterval;
         $this->storagePath = $storagePath;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -55,7 +55,7 @@ class Validator
      *
      * @param Vies\Client $client        (optional)
      */
-    public function __construct(Vies\Client $client = null)
+    public function __construct(?Vies\Client $client = null)
     {
         $this->client = $client ?: new Vies\Client();
     }


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated in PHP 8.4